### PR TITLE
Introduce named mappings to model loading, with properly implemented interpolate after merge

### DIFF
--- a/consts/consts.go
+++ b/consts/consts.go
@@ -51,3 +51,4 @@ const (
 type ComposeFileKey struct{}
 type WorkingDirKey struct{}
 type LookupValueKey struct{}
+type NamedMappingsKey struct{}

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -49,3 +49,4 @@ const (
 )
 
 type ComposeFileKey struct{}
+type WorkingDirKey struct{}

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -29,6 +29,7 @@ const Extensions = "#extensions" // Using # prefix, we prevent risk to conflict 
 const (
 	HostEnvMapping = "env"
 	ProjectMapping = "project"
+	ComposeMapping = "compose"
 
 	ServiceMapping   = "service"
 	ImageMapping     = "image"
@@ -50,5 +51,7 @@ const (
 
 type ComposeFileKey struct{}
 type WorkingDirKey struct{}
+type ProjectDirKey struct{}
+type ProjectNameKey struct{}
 type LookupValueKey struct{}
 type NamedMappingsKey struct{}

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -50,3 +50,4 @@ const (
 
 type ComposeFileKey struct{}
 type WorkingDirKey struct{}
+type LookupValueKey struct{}

--- a/interpolation/interpolation.go
+++ b/interpolation/interpolation.go
@@ -104,7 +104,7 @@ func recursiveInterpolate(value interface{}, path tree.Path, opts Options, named
 	case []interface{}:
 		out := make([]interface{}, len(value))
 		for i, elem := range value {
-			interpolatedElem, err := recursiveInterpolate(elem, path.Next(tree.PathMatchList), opts, namedMappings)
+			interpolatedElem, err := recursiveInterpolate(elem, path.NextIndex(i), opts, namedMappings)
 			if err != nil {
 				return out, err
 			}

--- a/interpolation/interpolation_test.go
+++ b/interpolation/interpolation_test.go
@@ -196,19 +196,24 @@ func TestInterpolateWithCast(t *testing.T) {
 	config := map[string]interface{}{
 		"foo": map[string]interface{}{
 			"replicas": "$count",
+			"ports":    []interface{}{"$count", "80"},
 		},
 	}
 	toInt := func(value string) (interface{}, error) {
 		return strconv.Atoi(value)
 	}
 	result, err := Interpolate(config, Options{
-		LookupValue:     defaultMapping,
-		TypeCastMapping: map[tree.Path]Cast{tree.NewPath(tree.PathMatchAll, "replicas"): toInt},
+		LookupValue: defaultMapping,
+		TypeCastMapping: map[tree.Path]Cast{
+			tree.NewPath(tree.PathMatchAll, "replicas"):                  toInt,
+			tree.NewPath(tree.PathMatchAll, "ports", tree.PathMatchList): toInt,
+		},
 	})
 	assert.NilError(t, err)
 	expected := map[string]interface{}{
 		"foo": map[string]interface{}{
 			"replicas": 5,
+			"ports":    []interface{}{5, 80},
 		},
 	}
 	assert.Check(t, is.DeepEqual(expected, result))

--- a/interpolation/namedmappings.go
+++ b/interpolation/namedmappings.go
@@ -30,29 +30,31 @@ type NamedMappingsResolver interface {
 
 	// Resolve resolves named mappings based on model's value at the given path
 	Resolve(ctx context.Context, value interface{}, path tree.Path, opts Options) (template.NamedMappings, error)
+
+	// ResolveGlobal resolves named mappings simply based on provided context, before any model value is available
+	ResolveGlobal(ctx context.Context, opts Options) (template.NamedMappings, error)
 }
 
 type EnvNamedMappingsResolver struct{}
 
 func (r EnvNamedMappingsResolver) Accept(path tree.Path) bool {
-	return path == "" // EnvNamedMappingsResolver applies at global level
+	return false // EnvNamedMappingsResolver does not resolve named mappings based on model's value
 }
 
 func (r EnvNamedMappingsResolver) Resolve(ctx context.Context, value interface{}, path tree.Path, opts Options) (template.NamedMappings, error) {
+	return nil, nil
+}
+
+func (r EnvNamedMappingsResolver) ResolveGlobal(ctx context.Context, opts Options) (template.NamedMappings, error) {
 	return template.NamedMappings{
 		consts.HostEnvMapping: template.ToVariadicMapping(template.Mapping(opts.LookupValue)),
 	}, nil
 }
 
 func ResolveNamedMappings(ctx context.Context, value interface{}, opts Options, resolvers []NamedMappingsResolver) (namedMappings map[tree.Path]template.NamedMappings, err error) {
-	namedMappings = map[tree.Path]template.NamedMappings{}
-
-	// Deep copy namedMappings from opts as initial
-	for path, mappings := range opts.NamedMappings {
-		namedMappings[path] = template.NamedMappings{}
-		for key, mapping := range mappings {
-			namedMappings[path][key] = mapping
-		}
+	namedMappings, err = ResolveGlobalNamedMappings(ctx, opts, resolvers)
+	if err != nil {
+		return nil, err
 	}
 	opts.NamedMappings = namedMappings // All resolvers will use and update this same underlying named mappings
 
@@ -97,6 +99,30 @@ func recursiveResolveNamedMappings(ctx context.Context, value interface{}, path 
 	}
 
 	return nil
+}
+
+func ResolveGlobalNamedMappings(ctx context.Context, opts Options, resolvers []NamedMappingsResolver) (namedMappings map[tree.Path]template.NamedMappings, err error) {
+	namedMappings = map[tree.Path]template.NamedMappings{}
+
+	// Deep copy namedMappings from opts as initial
+	for path, mappings := range opts.NamedMappings {
+		namedMappings[path] = template.NamedMappings{}
+		for key, mapping := range mappings {
+			namedMappings[path][key] = mapping
+		}
+	}
+	opts.NamedMappings = namedMappings // All resolvers will use and update this same underlying named mappings
+
+	globalPath := tree.NewPath()
+	for _, resolver := range resolvers {
+		resolved, err := resolver.ResolveGlobal(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		namedMappings[globalPath] = namedMappings[globalPath].Merge(resolved) // The early resolved named mappings take priority
+	}
+
+	return namedMappings, nil
 }
 
 func MergeNamedMappings(namedMappings map[tree.Path]template.NamedMappings, other map[tree.Path]template.NamedMappings) map[tree.Path]template.NamedMappings {

--- a/interpolation/namedmappings.go
+++ b/interpolation/namedmappings.go
@@ -88,8 +88,8 @@ func recursiveResolveNamedMappings(ctx context.Context, value interface{}, path 
 			}
 		}
 	case []interface{}:
-		for _, elem := range value {
-			err := recursiveResolveNamedMappings(ctx, elem, tree.PathMatchList, opts, resolver, namedMappings)
+		for i, elem := range value {
+			err := recursiveResolveNamedMappings(ctx, elem, path.NextIndex(i), opts, resolver, namedMappings)
 			if err != nil {
 				return err
 			}

--- a/interpolation/namedmappings_test.go
+++ b/interpolation/namedmappings_test.go
@@ -76,6 +76,10 @@ func (numberNamedMappingsResolver) Resolve(ctx context.Context, value interface{
 	}, nil
 }
 
+func (numberNamedMappingsResolver) ResolveGlobal(ctx context.Context, opts Options) (template.NamedMappings, error) {
+	return nil, nil
+}
+
 func TestInterpolateWithNamedMappings(t *testing.T) {
 	namedMappings := map[tree.Path]template.NamedMappings{
 		tree.NewPath(): { // global level

--- a/loader/extends.go
+++ b/loader/extends.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/consts"
 	"github.com/compose-spec/compose-go/v2/override"
+	"github.com/compose-spec/compose-go/v2/tree"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/compose-spec/compose-go/v2/utils"
 )
@@ -65,9 +66,16 @@ func applyServiceExtends(ctx context.Context, name string, services map[string]a
 		return s, nil
 	}
 	extends = utils.UnwrapPair(extends) // Use unwrapped extends model
+	var err error
+	if opts.Interpolate != nil && !opts.SkipInterpolation {
+		interpOpts := *opts.Interpolate
+		extends, err = interpolateWithPath(tree.NewPath("services", name, "extends"), extends, interpOpts)
+		if err != nil {
+			return nil, err
+		}
+	}
 	filename := ctx.Value(consts.ComposeFileKey{}).(string)
 	var (
-		err  error
 		ref  string
 		file any
 	)

--- a/loader/extends.go
+++ b/loader/extends.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/consts"
 	"github.com/compose-spec/compose-go/v2/override"
+	"github.com/compose-spec/compose-go/v2/template"
 	"github.com/compose-spec/compose-go/v2/tree"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/compose-spec/compose-go/v2/utils"
@@ -69,6 +70,9 @@ func applyServiceExtends(ctx context.Context, name string, services map[string]a
 	var err error
 	if opts.Interpolate != nil && !opts.SkipInterpolation {
 		interpOpts := *opts.Interpolate
+		if namedMappings, ok := ctx.Value(consts.NamedMappingsKey{}).(map[tree.Path]template.NamedMappings); ok {
+			interpOpts.NamedMappings = namedMappings
+		}
 		extends, err = interpolateWithPath(tree.NewPath("services", name, "extends"), extends, interpOpts)
 		if err != nil {
 			return nil, err

--- a/loader/extends_test.go
+++ b/loader/extends_test.go
@@ -150,10 +150,10 @@ services:
 		},
 		WorkingDir: abs,
 	}, func(options *Options) {
-		options.ResolvePaths = false
+		options.ResolvePaths = true
 	})
 	assert.NilError(t, err)
-	assert.Equal(t, p.Services["test"].Build.Context, filepath.Join("testdata", "extends"))
+	assert.Equal(t, p.Services["test"].Build.Context, filepath.Join(abs, "testdata", "extends"))
 }
 
 func TestExtendsNil(t *testing.T) {

--- a/loader/include.go
+++ b/loader/include.go
@@ -116,6 +116,7 @@ func ApplyInclude(ctx context.Context, workingDir string, environment types.Mapp
 		loadOptions.ResourceLoaders = append(loadOptions.RemoteResourceLoaders(), localResourceLoader{
 			WorkingDir: r.ProjectDirectory,
 		})
+		loadOptions.SetProjectName(filepath.Base(r.ProjectDirectory), false)
 
 		if len(r.EnvFile) == 0 {
 			f := filepath.Join(r.ProjectDirectory, ".env")
@@ -155,6 +156,13 @@ func ApplyInclude(ctx context.Context, workingDir string, environment types.Mapp
 			LookupValue:     config.LookupEnv,
 			TypeCastMapping: options.Interpolate.TypeCastMapping,
 		}
+		err = projectName(&config, loadOptions)
+		if err != nil {
+			return err
+		}
+
+		ctx = context.WithValue(ctx, consts.ProjectNameKey{}, loadOptions.projectName)
+		ctx = context.WithValue(ctx, consts.ProjectDirKey{}, r.ProjectDirectory)
 		if len(envFromFile) > 0 {
 			ctx = context.WithValue(ctx, consts.LookupValueKey{}, interp.LookupValue(config.LookupEnv))
 		}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/consts"
@@ -772,7 +771,7 @@ func processExtensions(dict map[string]any, p tree.Path, extensions map[string]a
 		case []interface{}:
 			for i, e := range v {
 				if m, ok := e.(map[string]interface{}); ok {
-					v[i], err = processExtensions(m, p.Next(strconv.Itoa(i)), extensions)
+					v[i], err = processExtensions(m, p.NextIndex(i), extensions)
 					if err != nil {
 						return nil, err
 					}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -428,6 +428,19 @@ func loadYamlModel(ctx context.Context, config types.ConfigDetails, opts *Option
 		}
 	}
 
+	dict, err = transform.Canonical(dict, opts.SkipInterpolation)
+	if err != nil {
+		return nil, err
+	}
+
+	dict = OmitEmpty(dict)
+
+	// Canonical transformation can reveal duplicates, typically as ports can be a range and conflict with an override
+	dict, err = override.EnforceUnicity(dict)
+	if err != nil {
+		return nil, err
+	}
+
 	if !opts.SkipDefaultValues {
 		dict, err = transform.SetDefaultValues(dict)
 		if err != nil {
@@ -530,15 +543,6 @@ func loadYamlFile(ctx context.Context, file types.ConfigFile, opts *Options, wor
 			}
 		}
 
-		dict, err = transform.Canonical(dict, opts.SkipInterpolation)
-		if err != nil {
-			return err
-		}
-
-		dict = OmitEmpty(dict)
-
-		// Canonical transformation can reveal duplicates, typically as ports can be a range and conflict with an override
-		dict, err = override.EnforceUnicity(dict)
 		return err
 	}
 

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -31,6 +31,7 @@ import (
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 
+	interp "github.com/compose-spec/compose-go/v2/interpolation"
 	"github.com/compose-spec/compose-go/v2/types"
 )
 
@@ -913,6 +914,426 @@ networks:
 	}
 
 	assertEqual(t, expected, config)
+}
+
+func TestLoadWithInterpolationNamedMappings(t *testing.T) {
+	dict := `
+name: test-project
+
+services:
+  service_1:
+    image: image:${service[name]}
+    container_name: container.${service[name]}
+    user: ${env[USER]}
+    working_dir: ${env[PWD]}
+    x-test-field-1: ${image[name]} ${container[name]} ${service[scale]}
+    x-test-field-2: ${container[user]} ${container[working-dir]}
+    x-test-field-3: ${container[image][name]} ${service[containers][0][image]}
+    labels:
+      "foo_from_env_file": "3"
+    environment:
+      "NUMBER": ${labels[${container[env][FOO]}]}
+    env_file: example1.env
+
+networks:
+  network_1:
+    name: ${network[driver]}-network
+    driver: bridge
+    x-test-field: ${network[name]} ${network[external]}
+
+volumes:
+  volume_1:
+    name: ${volume[driver]}-volume
+    driver: overlay
+    x-test-field: ${volume[name]} ${volume[external]}
+
+configs:
+  config_1:
+    name: ${config[content]}-config
+    content: test
+    x-test-field: ${config[name]} ${config[content]} ${config[data]}
+
+secrets:
+  secret_1:
+    environment: PWD
+    x-test-field: ${secret[data]}
+  secret_2:
+    file: testdata/file/access_key.txt
+    x-test-field: ${secret[data]}
+`
+	env := map[string]string{
+		"USER": "test-user",
+		"PWD":  os.Getenv("PWD"),
+	}
+
+	configDetails := buildConfigDetails(dict, env)
+	config, err := Load(configDetails, func(options *Options) {
+		options.SkipNormalization = true
+		options.SkipConsistencyCheck = true
+		options.NamedMappingsResolvers = []interp.NamedMappingsResolver{
+			interp.EnvNamedMappingsResolver{},
+			NewModelNamedMappingsResolver(configDetails, options),
+		}
+	})
+	assert.NilError(t, err)
+
+	workingDir, err := os.Getwd()
+	assert.NilError(t, err)
+
+	expected := &types.Project{
+		Name:        "test-project",
+		Environment: env,
+		WorkingDir:  workingDir,
+		Services: types.Services{
+			"service_1": {
+				Name:          "service_1",
+				ContainerName: "container.service_1",
+				Image:         "image:service_1",
+				User:          "test-user",
+				WorkingDir:    env["PWD"],
+				Extensions: types.Extensions{
+					"x-test-field-1": fmt.Sprintf("%s %s %d", "image:service_1", "container.service_1", 1),
+					"x-test-field-2": fmt.Sprintf("%s %s", "test-user", env["PWD"]),
+					"x-test-field-3": fmt.Sprintf("%s %s", "image:service_1", "image:service_1"),
+				},
+				Labels: types.Labels{
+					"foo_from_env_file": "3",
+				},
+				Environment: types.MappingWithEquals{
+					"BAR":                 strPtr("bar_from_env_file"),
+					"BAZ":                 strPtr("baz_from_env_file"),
+					"ENV.WITH.DOT":        strPtr("ok"),
+					"ENV_WITH_UNDERSCORE": strPtr("ok"),
+					"FOO":                 strPtr("foo_from_env_file"),
+					"NUMBER":              strPtr("3"),
+				},
+				EnvFiles: []types.EnvFile{
+					{
+						Path:     filepath.Join(workingDir, "example1.env"),
+						Required: true,
+					},
+				},
+			},
+		},
+		Networks: types.Networks{
+			"network_1": {
+				Name:   "bridge-network",
+				Driver: "bridge",
+				Extensions: types.Extensions{
+					"x-test-field": "bridge-network false",
+				},
+			},
+		},
+		Volumes: types.Volumes{
+			"volume_1": {
+				Name:   "overlay-volume",
+				Driver: "overlay",
+				Extensions: types.Extensions{
+					"x-test-field": "overlay-volume false",
+				},
+			},
+		},
+		Configs: types.Configs{
+			"config_1": {
+				Name:    "test-config",
+				Content: "test",
+				Extensions: types.Extensions{
+					"x-test-field": "test-config test test",
+				},
+			},
+		},
+		Secrets: types.Secrets{
+			"secret_1": {
+				Environment: "PWD",
+				Content:     workingDir,
+				Extensions: types.Extensions{
+					"x-test-field": workingDir,
+				},
+			},
+			"secret_2": {
+				File: filepath.Join(workingDir, "testdata/file/access_key.txt"),
+				Extensions: types.Extensions{
+					"x-test-field": "12345678-abcd-11ef-a236-d7497f4e9904",
+				},
+			},
+		},
+	}
+	assertEqual(t, config, expected)
+}
+
+func TestLoadWithInterpolationNamedMappingsWithIncludesExtends(t *testing.T) {
+	fileName := "compose.yml"
+	tmpdir := t.TempDir()
+	env := map[string]string{}
+
+	// file in root (includes /module/compose.yml)
+	yaml := `
+name: test-project
+x-project-fields: ${project[name]} ${project[working-dir]}
+x-compose-fields: ${compose[root-dir]} ${compose[config-dir]}
+x-var-name: ${env[VAR_NAME]}
+
+include:
+  - path: ${project[working-dir]}/module/compose.yml`
+	path := createFile(t, tmpdir, yaml, fileName)
+	createFile(t, tmpdir, `VAR_NAME=value`, "custom.env")
+
+	// file in /module (includes /module/submodule/compose.yml, service extends /extends/compose.yml)
+	yaml = `
+include:
+  - path: ${compose[root-dir]}/module/submodule/compose.yml
+    env_file: ../custom.env
+
+services:
+  service-module:
+    extends:
+      file: ../extends/compose.yml
+      service: service-extends
+    x-project-fields: ${project[name]} ${project[working-dir]}
+    x-compose-fields: ${compose[root-dir]} ${compose[config-dir]}
+    x-var-name: ${env[VAR_NAME]}`
+	createFileSubDir(t, tmpdir, "module", yaml, fileName)
+
+	// file in /extends
+	yaml = `
+services:
+  service-extends:
+    image: alpine
+    environment:
+      - VAR_NAME
+    x-project-fields: ${project[name]} ${project[working-dir]}
+    x-compose-fields: ${compose[root-dir]} ${compose[config-dir]}`
+	createFileSubDir(t, tmpdir, "extends", yaml, fileName)
+
+	// file in /module/submodule (service extends /extends/compose.yml)
+	yaml = `
+services:
+  service-submodule:
+    extends:
+      file: ${compose[root-dir]}/extends/compose.yml
+      service: service-extends
+    x-var-name: ${env[VAR_NAME]}`
+	createFileSubDir(t, tmpdir, "module/submodule", yaml, fileName)
+
+	configDetails := types.ConfigDetails{
+		WorkingDir: tmpdir,
+		ConfigFiles: []types.ConfigFile{{
+			Filename: path,
+		}},
+		Environment: env,
+	}
+	config, err := Load(configDetails, func(options *Options) {
+		options.SkipNormalization = true
+		options.SkipConsistencyCheck = true
+		options.NamedMappingsResolvers = []interp.NamedMappingsResolver{
+			interp.EnvNamedMappingsResolver{},
+			NewModelNamedMappingsResolver(configDetails, options),
+		}
+	})
+	assert.NilError(t, err)
+
+	expected := &types.Project{
+		Name:        "test-project",
+		Environment: env,
+		WorkingDir:  tmpdir,
+		Extensions: types.Extensions{
+			// Project dir, compose root and compose conf dir are / in root context
+			"x-project-fields": fmt.Sprintf("%s %s", "test-project", tmpdir),
+			"x-compose-fields": fmt.Sprintf("%s %s", tmpdir, tmpdir),
+			"x-var-name":       "",
+		},
+		Services: types.Services{
+			"service-module": {
+				Name:  "service-module",
+				Image: "alpine",
+				Environment: types.MappingWithEquals{
+					"VAR_NAME": nil,
+				},
+				Extensions: types.Extensions{
+					// /module/compose.yml is included, so ${project[working-dir]} is /module
+					"x-project-fields": fmt.Sprintf("%s %s", "module", filepath.Join(tmpdir, "module")),
+					// This field is not overriden by extends, so ${compose[config-dir]} is still /module
+					"x-compose-fields": fmt.Sprintf("%s %s", tmpdir, filepath.Join(tmpdir, "module")),
+					"x-var-name":       "",
+				},
+			},
+			"service-submodule": {
+				Name:  "service-submodule",
+				Image: "alpine",
+				Environment: types.MappingWithEquals{
+					"VAR_NAME": strPtr("value"),
+				},
+				Extensions: types.Extensions{
+					// Though this field is from extends, extends does not change project dir, so ${project[working-dir]} is /module/submodule
+					"x-project-fields": fmt.Sprintf("%s %s", "submodule", filepath.Join(tmpdir, "module/submodule")),
+					// This field is from extends, so ${compose[config-dir]} is the dir of /extends/compose.yml (/extends)
+					"x-compose-fields": fmt.Sprintf("%s %s", tmpdir, filepath.Join(tmpdir, "extends")),
+					"x-var-name":       "value",
+				},
+			},
+		},
+	}
+	assertEqual(t, config, expected)
+}
+
+func TestLoadWithInterpolationNamedMappingsWithCrossScopeReference(t *testing.T) {
+	fileName := "compose.yml"
+	tmpdir := t.TempDir()
+	env := map[string]string{
+		"USER":         "jenny",
+		"TESTDATA_DIR": filepath.Join(os.Getenv("PWD"), "testdata"),
+	}
+
+	// file in root
+	yaml := `
+name: test-project
+
+include:
+  - path: ./module1/compose.yml
+  - path: ./module2/compose.yml`
+	path := createFile(t, tmpdir, yaml, fileName)
+	createFile(t, tmpdir, `VAR_NAME=value`, "custom.env")
+	createFile(t, tmpdir, `LABEL_NAME=value`, "custom.label")
+
+	// file in /module1
+	yaml = `
+services:
+  service_1:
+    image: test-image
+    container_name: test-container
+    env_file: ../custom.env
+    label_file: ../custom.label
+    x-test-field-1: ${configs[user_from_file]} ${configs[user_from_env]} ${configs[user_from_content]}
+    x-test-field-2: ${secrets[user_from_env]} ${secrets[access_key]}
+
+networks:
+  network_1:
+    name: test-network
+    driver: bridge
+    x-test-field: ${services[service_1][scale]} ${containers[test-container][image]}
+
+configs:
+  user_from_file:
+    file: ${env[TESTDATA_DIR]}/file/user.txt
+  user_from_env:
+    environment: USER
+
+secrets:
+  user_from_env:
+    environment: USER
+    x-test-field: secret-${configs[user_from_content]}`
+	createFileSubDir(t, tmpdir, "module1", yaml, fileName)
+
+	// file in /module2
+	yaml = `
+volumes:
+  volume_1:
+    driver: overlay
+    x-test-field: ${networks[test-network][driver]}
+
+configs:
+  user_from_content:
+    content: content-${configs[user_from_file]}
+    x-test-field: ${volumes[volume_1][driver]}
+
+secrets:
+  access_key:
+    file: ${env[TESTDATA_DIR]}/file/access_key.txt
+    x-test-field: ${containers[test-container][env][VAR_NAME]} ${containers[test-container][labels][LABEL_NAME]}`
+	createFileSubDir(t, tmpdir, "module2", yaml, fileName)
+
+	configDetails := types.ConfigDetails{
+		WorkingDir: tmpdir,
+		ConfigFiles: []types.ConfigFile{{
+			Filename: path,
+		}},
+		Environment: env,
+	}
+	config, err := Load(configDetails, func(options *Options) {
+		options.SkipNormalization = true
+		options.SkipConsistencyCheck = true
+		options.NamedMappingsResolvers = []interp.NamedMappingsResolver{
+			interp.EnvNamedMappingsResolver{},
+			NewModelNamedMappingsResolver(configDetails, options),
+		}
+	})
+	assert.NilError(t, err)
+
+	expected := &types.Project{
+		Name:        "test-project",
+		Environment: env,
+		WorkingDir:  tmpdir,
+		Services: types.Services{
+			"service_1": {
+				Name:          "service_1",
+				Image:         "test-image",
+				ContainerName: "test-container",
+				Environment:   types.MappingWithEquals{"VAR_NAME": strPtr("value")},
+				EnvFiles: []types.EnvFile{
+					{
+						Path:     filepath.Join(tmpdir, "custom.env"),
+						Required: true,
+					},
+				},
+				Labels: types.Labels{"LABEL_NAME": "value"},
+				LabelFiles: []string{
+					filepath.Join(tmpdir, "custom.label"),
+				},
+				Extensions: types.Extensions{
+					"x-test-field-1": "test-user jenny content-test-user",
+					"x-test-field-2": "jenny 12345678-abcd-11ef-a236-d7497f4e9904",
+				},
+			},
+		},
+		Networks: types.Networks{
+			"network_1": {
+				Name:   "test-network",
+				Driver: "bridge",
+				Extensions: types.Extensions{
+					"x-test-field": "1 test-image",
+				},
+			},
+		},
+		Volumes: types.Volumes{
+			"volume_1": {
+				Driver: "overlay",
+				Extensions: types.Extensions{
+					"x-test-field": "bridge",
+				},
+			},
+		},
+		Configs: map[string]types.ConfigObjConfig{
+			"user_from_file": {
+				File: filepath.Join(os.Getenv("PWD"), "testdata/file/user.txt"),
+			},
+			"user_from_env": {
+				Environment: "USER",
+				Content:     "jenny",
+			},
+			"user_from_content": {
+				Content: "content-test-user",
+				Extensions: types.Extensions{
+					"x-test-field": "overlay",
+				},
+			},
+		},
+		Secrets: map[string]types.SecretConfig{
+			"user_from_env": {
+				Environment: "USER",
+				Content:     "jenny",
+				Extensions: types.Extensions{
+					"x-test-field": "secret-content-test-user",
+				},
+			},
+			"access_key": {
+				File: filepath.Join(os.Getenv("PWD"), "testdata/file/access_key.txt"),
+				Extensions: types.Extensions{
+					"x-test-field": "value value",
+				},
+			},
+		},
+	}
+	assertEqual(t, config, expected)
 }
 
 func TestUnsupportedProperties(t *testing.T) {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -451,7 +451,7 @@ services:
 
 	svcB, err := actual.GetService("b")
 	assert.NilError(t, err)
-	assert.Equal(t, svcB.Build.Context, tmpdir)
+	assert.Equal(t, svcB.Build.Context, bDir)
 }
 
 func TestLoadExtendsWihReset(t *testing.T) {

--- a/loader/namedmappings.go
+++ b/loader/namedmappings.go
@@ -77,7 +77,6 @@ func (r *modelNamedMappingsResolver) Resolve(ctx context.Context, value interfac
 	switch {
 	case path.Matches(tree.NewPath()):
 		return template.NamedMappings{
-			consts.ProjectMapping:    template.ToVariadicMapping(func(keys ...string) (string, bool) { return r.projectMapping(scope, keys...) }),
 			consts.ServicesMapping:   template.ToVariadicMapping(func(keys ...string) (string, bool) { return r.crossRefMapping(scope, consts.ServiceMapping, keys...) }),
 			consts.ContainersMapping: template.ToVariadicMapping(func(keys ...string) (string, bool) { return r.crossRefMapping(scope, consts.ContainerMapping, keys...) }),
 			consts.NetworksMapping:   template.ToVariadicMapping(func(keys ...string) (string, bool) { return r.crossRefMapping(scope, consts.NetworkMapping, keys...) }),
@@ -115,6 +114,18 @@ func (r *modelNamedMappingsResolver) Resolve(ctx context.Context, value interfac
 	default:
 		return nil, fmt.Errorf("unsupported path for modelNamedMappingsResolver: %s", path)
 	}
+}
+
+func (r *modelNamedMappingsResolver) ResolveGlobal(ctx context.Context, opts interp.Options) (template.NamedMappings, error) {
+	scope := &modelNamedMappingsScope{
+		ctx:          ctx,
+		opts:         opts,
+		caches:       map[string]map[string]*string{},
+		cycleTracker: map[string]map[string]bool{},
+	}
+	return template.NamedMappings{
+		consts.ProjectMapping: template.ToVariadicMapping(func(keys ...string) (string, bool) { return r.projectMapping(scope, keys...) }),
+	}, nil
 }
 
 func (r *modelNamedMappingsResolver) projectMapping(_ *modelNamedMappingsScope, keys ...string) (string, bool) {

--- a/loader/namedmappings.go
+++ b/loader/namedmappings.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/compose-spec/compose-go/v2/consts"
@@ -125,15 +126,48 @@ func (r *modelNamedMappingsResolver) ResolveGlobal(ctx context.Context, opts int
 	}
 	return template.NamedMappings{
 		consts.ProjectMapping: template.ToVariadicMapping(func(keys ...string) (string, bool) { return r.projectMapping(scope, keys...) }),
+		consts.ComposeMapping: template.ToVariadicMapping(func(keys ...string) (string, bool) { return r.composeMapping(scope, keys...) }),
 	}, nil
 }
 
-func (r *modelNamedMappingsResolver) projectMapping(_ *modelNamedMappingsScope, keys ...string) (string, bool) {
+func (r *modelNamedMappingsResolver) projectMapping(scope *modelNamedMappingsScope, keys ...string) (string, bool) {
 	switch keys[0] {
 	case "name":
+		if name, ok := scope.ctx.Value(consts.ProjectNameKey{}).(string); ok {
+			return name, true
+		}
 		return r.opts.projectName, true
 	case "working-dir": // TODO: working_dir or working-dir?
+		if path, ok := scope.ctx.Value(consts.ProjectDirKey{}).(string); ok {
+			return path, true
+		}
 		return r.configDetails.WorkingDir, true
+	}
+	return "", false
+}
+
+func (r *modelNamedMappingsResolver) composeMapping(scope *modelNamedMappingsScope, keys ...string) (string, bool) {
+	switch keys[0] {
+	case "root-dir":
+		return r.configDetails.WorkingDir, true
+	case "working-dir":
+		if path, ok := scope.ctx.Value(consts.WorkingDirKey{}).(string); ok {
+			return path, true
+		}
+		return r.configDetails.WorkingDir, true
+	case "config-dir":
+		return scope.cachedMapping(consts.ComposeMapping, keys[0], func() (string, bool) {
+			if path, ok := scope.ctx.Value(consts.ComposeFileKey{}).(string); ok {
+				for _, loader := range r.opts.ResourceLoaders {
+					if loader.Accept(path) {
+						path = utils.Must(loader.Load(scope.ctx, path))
+						path = utils.Must(filepath.Abs(path))
+						return filepath.Dir(path), true
+					}
+				}
+			}
+			return "", false
+		})
 	}
 	return "", false
 }
@@ -304,7 +338,7 @@ func (r *modelNamedMappingsResolver) fileObjectMapping(scope *modelNamedMappings
 			if value := fileObject["file"]; value != nil {
 				model := wrapValueWithPath(scope.path.Next("file"), value)
 				model = utils.Must(interp.Interpolate(model, scope.opts))
-				model = utils.Must(model, paths.ResolveRelativePaths(model, r.configDetails.WorkingDir, r.opts.RemoteResourceFilters()))
+				model = utils.Must(r.resolveRelativePaths(scope, model))
 				return unwrapValueWithPath(scope.path.Next("file"), model).(string), true
 			}
 			return "", false
@@ -352,7 +386,7 @@ func (r *modelNamedMappingsResolver) containerEnvMapping(scope *modelNamedMappin
 			model = utils.Must(transform.Canonical(model, false))
 
 			// Resolve env_file path to absolute
-			utils.Must(model, paths.ResolveRelativePaths(model, r.configDetails.WorkingDir, r.opts.RemoteResourceFilters()))
+			model = utils.Must(r.resolveRelativePaths(scope, model))
 
 			// Apply modelToProject to reuse `WithServicesEnvironmentResolved` logic
 			project := utils.Must(r.modelToProject(model))
@@ -384,7 +418,7 @@ func (r *modelNamedMappingsResolver) labelsMapping(scope *modelNamedMappingsScop
 			model = utils.Must(transform.Canonical(model, false))
 
 			// Resolve label_file path to absolute
-			utils.Must(model, paths.ResolveRelativePaths(model, r.configDetails.WorkingDir, r.opts.RemoteResourceFilters()))
+			model = utils.Must(r.resolveRelativePaths(scope, model))
 
 			// Apply modelToProject to reuse `Labels.DecodeMapstructure` logic
 			project := utils.Must(r.modelToProject(model))
@@ -486,6 +520,19 @@ func (r *modelNamedMappingsResolver) modelToProject(model map[string]interface{}
 	opts := r.opts.clone()
 	opts.SkipConsistencyCheck = true
 	return modelToProject(model, opts, r.configDetails)
+}
+
+func (r *modelNamedMappingsResolver) resolveRelativePaths(scope *modelNamedMappingsScope, model map[string]interface{}) (map[string]interface{}, error) {
+	model = utils.WrapPair(model, func(path tree.Path, _ any) any {
+		if composeMapping, ok := interp.LookupNamedMappings(scope.opts.NamedMappings, path)[consts.ComposeMapping]; ok {
+			if workingDir, ok := composeMapping("working-dir"); ok {
+				return workingDir
+			}
+		}
+		return nil // Will be omitted by `utils.UnwrapPairWithValues[string]`
+	})
+	model, workingDirMapping := utils.UnwrapPairWithValues[string](model)
+	return model, paths.ResolveRelativePathsWithBaseMapping(model, r.configDetails.WorkingDir, r.opts.RemoteResourceFilters(), workingDirMapping)
 }
 
 func (s *modelNamedMappingsScope) cachedMapping(name string, key string, onCacheMiss func() (string, bool)) (string, bool) {

--- a/loader/omitEmpty.go
+++ b/loader/omitEmpty.go
@@ -44,12 +44,12 @@ func omitEmpty(data any, p tree.Path) any {
 		return v
 	case []any:
 		var c []any
-		for _, e := range v {
+		for i, e := range v {
 			if isEmpty(e) && mustOmit(p) {
 				continue
 			}
 
-			c = append(c, omitEmpty(e, p.Next("[]")))
+			c = append(c, omitEmpty(e, p.NextIndex(i)))
 		}
 		return c
 	default:

--- a/loader/omitEmpty.go
+++ b/loader/omitEmpty.go
@@ -16,7 +16,10 @@
 
 package loader
 
-import "github.com/compose-spec/compose-go/v2/tree"
+import (
+	"github.com/compose-spec/compose-go/v2/tree"
+	"github.com/compose-spec/compose-go/v2/utils"
+)
 
 var omitempty = []tree.Path{
 	"services.*.dns"}
@@ -64,11 +67,14 @@ func mustOmit(p tree.Path) bool {
 }
 
 func isEmpty(e any) bool {
-	if e == nil {
+	switch e := e.(type) {
+	case utils.Pair:
+		return isEmpty(e.First)
+	case string:
+		return e == ""
+	case nil:
 		return true
+	default:
+		return false
 	}
-	if v, ok := e.(string); ok && v == "" {
-		return true
-	}
-	return false
 }

--- a/loader/reset.go
+++ b/loader/reset.go
@@ -18,7 +18,6 @@ package loader
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/tree"
@@ -71,7 +70,7 @@ func (p *ResetProcessor) resolveReset(node *yaml.Node, path tree.Path) (*yaml.No
 	case yaml.SequenceNode:
 		var nodes []*yaml.Node
 		for idx, v := range node.Content {
-			next := path.Next(strconv.Itoa(idx))
+			next := path.NextIndex(idx)
 			resolved, err := p.resolveReset(v, next)
 			if err != nil {
 				return nil, err
@@ -128,7 +127,7 @@ func (p *ResetProcessor) applyNullOverrides(target any, path tree.Path) error {
 	case []any:
 	ITER:
 		for i, e := range v {
-			next := path.Next(fmt.Sprintf("[%d]", i))
+			next := path.NextIndex(i)
 			for _, pattern := range p.paths {
 				if next.Matches(pattern) {
 					continue ITER

--- a/override/merge_annotations_test.go
+++ b/override/merge_annotations_test.go
@@ -37,12 +37,12 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     annotations:
-      - FOO=BAR
-      - QIX=ZOT
-      - EMPTY=
-      - NIL
+      - !right FOO=BAR
+      - !left  QIX=ZOT
+      - !left  EMPTY=
+      - !left  NIL
 `)
 }
 
@@ -63,12 +63,12 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     annotations:
-      - FOO=BAR
-      - EMPTY=
-      - NIL
-      - QIX=ZOT
+      - !right FOO=BAR
+      - !left  EMPTY=
+      - !left  NIL
+      - !left  QIX=ZOT
 `)
 }
 
@@ -87,10 +87,10 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     annotations:
-      - FOO=BAR
-      - QIX=ZOT
+      - !right FOO=BAR
+      - !left  QIX=ZOT
 `)
 }
 
@@ -109,6 +109,6 @@ services:
 services:
   test:
     annotations:
-      - FOO=3
+      - !left FOO=3
 `)
 }

--- a/override/merge_build_test.go
+++ b/override/merge_build_test.go
@@ -31,7 +31,7 @@ services:
       additional_contexts:
         - resources=/path/to/resources
         - app=docker-image://my-app:latest
-      platform: 
+      platform:
         - linux/amd64
       tags:
         - "myimage:mytag"
@@ -63,28 +63,28 @@ services:
 services:
   test:
     build:
-      context: .
+      context: !left .
       args:
-        - FOO=BAR
-        - GIT_COMMIT=cdc3b19
-        - EMPTY=
-        - NIL
+        - !right FOO=BAR
+        - !left GIT_COMMIT=cdc3b19
+        - !left EMPTY=
+        - !left NIL
       additional_contexts:
-        - resources=/path/to/resources
-        - app=docker-image://my-app:latest
-        - source=https://github.com/myuser/project.git
+        - !right resources=/path/to/resources
+        - !right app=docker-image://my-app:latest
+        - !left  source=https://github.com/myuser/project.git
       platform:
-        - "linux/amd64"
-        - "linux/arm64"
-        - "unsupported/unsupported"
+        - !left "linux/amd64"
+        - !left "linux/arm64"
+        - !left "unsupported/unsupported"
       tags:
-        - "myimage:mytag"
-        - "registry/username/myrepos:my-other-tag"
+        - !left "myimage:mytag"
+        - !left "registry/username/myrepos:my-other-tag"
       extra_hosts:
-        - "somehost=162.242.195.82"
-        - "otherhost=50.31.209.229"
-        - "otherhost=50.31.209.230"
-        - "myhostv6=::1"
+        - !right "somehost=162.242.195.82"
+        - !right "otherhost=50.31.209.229"
+        - !left  "otherhost=50.31.209.230"
+        - !left  "myhostv6=::1"
 `)
 }
 
@@ -114,16 +114,16 @@ services:
 services:
   test:
     build:
-      context: .
+      context: !left .
       args:
-       - FOO=BAR
-       - EMPTY=
-       - NIL
-       - QIX=ZOT
+       - !right FOO=BAR
+       - !left EMPTY=
+       - !left NIL
+       - !left QIX=ZOT
       additional_contexts:
-        - source=https://github.com/myuser/project.git
-        - app=docker-image://my-app:latest
-        - resources=/path/to/resources
+        - !right source=https://github.com/myuser/project.git
+        - !left  app=docker-image://my-app:latest
+        - !left  resources=/path/to/resources
 `)
 }
 
@@ -157,18 +157,18 @@ services:
 services:
   test:
     build:
-      context: .
+      context: !right .
       args:
-        - FOO=BAR
-        - QIX=ZOT
+        - !right FOO=BAR
+        - !left  QIX=ZOT
       additional_contexts:
-        - resources=/path/to/resources
-        - app=docker-image://new-app:latest
-        - source=https://github.com/myuser/project.git
-      platform: linux/amd64
+        - !right resources=/path/to/resources
+        - !left  app=docker-image://new-app:latest
+        - !left  source=https://github.com/myuser/project.git
+      platform: !right linux/amd64
       tags:
-        - "myimage:mytag"
-        - "registry/username/myrepos:my-other-tag"
+        - !right "myimage:mytag"
+        - !left  "registry/username/myrepos:my-other-tag"
 `)
 }
 
@@ -191,8 +191,8 @@ services:
 services:
   test:
     build:
-      context: .
+      context: !left .
       args:
-       - FOO=3
+       - !left FOO=3
 `)
 }

--- a/override/merge_cap_test.go
+++ b/override/merge_cap_test.go
@@ -43,14 +43,14 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     cap_add:
-      - CAP_BPF
-      - CAP_CHOWN
-      - CAP_KILL
+      - !right CAP_BPF
+      - !left  CAP_CHOWN
+      - !left  CAP_KILL
     cap_drop:
-      - NET_ADMIN
-      - SYS_ADMIN
-      - CAP_FOWNER
+      - !left  NET_ADMIN
+      - !right SYS_ADMIN
+      - !left  CAP_FOWNER
 `)
 }

--- a/override/merge_depends_on_test.go
+++ b/override/merge_depends_on_test.go
@@ -20,31 +20,32 @@ import (
 	"testing"
 )
 
-// override using the same logging driver will override driver options
-func Test_mergeYamlServiceMount(t *testing.T) {
+func TestMergeServiceDependsOn(t *testing.T) {
 	assertMergeYaml(t, `
 services:
   test:
     image: foo
-    secrets:
-      - foo
-      - bar
-      - zot
+    depends_on:
+      - dependency1
+      - dependency2
 `, `
 services:
   test:
-    image: foo
-    secrets:
-      - source: zot
-        target: /run/secrets/foo
+    depends_on:
+      dependency1:
+        condition: service_healthy
+      dependency3:
 `, `
 services:
   test:
-    image: !left foo
-    secrets:
-      - source: !left zot
-        target: !left /run/secrets/foo
-      - !right bar
-      - !right zot
+    image: !right foo
+    depends_on:
+      dependency1:
+        condition: !left service_healthy
+        required: !right true
+      dependency2:
+        condition: !right service_started
+        required: !right true
+      dependency3: !left
 `)
 }

--- a/override/merge_devices_test.go
+++ b/override/merge_devices_test.go
@@ -41,16 +41,16 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     devices:
-      - '/dev/sda:/dev/sda'
-      - '/dev/sdb:/dev/sdb'
-      - '/dev/sdc:/dev/sdc'
-      - '/dev/sdd:/dev/sdd'
-      - '/dev/sde:/dev/sde'
-      - '/dev/sdf:/dev/sdf'
-      - '/dev/sdg:/dev/sdg'
-      - '/dev/sdh:/dev/sdh'
+      - !right '/dev/sda:/dev/sda'
+      - !right '/dev/sdb:/dev/sdb'
+      - !right '/dev/sdc:/dev/sdc'
+      - !right '/dev/sdd:/dev/sdd'
+      - !left  '/dev/sde:/dev/sde'
+      - !left  '/dev/sdf:/dev/sdf'
+      - !left  '/dev/sdg:/dev/sdg'
+      - !left  '/dev/sdh:/dev/sdh'
 `)
 }
 
@@ -74,11 +74,11 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     devices:
-      - '/dev/nvme0n1p1:/dev/sda'
-      - '/dev/nvme1n1p1:/dev/sdb'
-      - '/dev/nvme2n1p1:/dev/sdc'
-      - '/dev/sdd:/dev/sdd'
+      - !left  '/dev/nvme0n1p1:/dev/sda'
+      - !left  '/dev/nvme1n1p1:/dev/sdb'
+      - !left  '/dev/nvme2n1p1:/dev/sdc'
+      - !right '/dev/sdd:/dev/sdd'
 `)
 }

--- a/override/merge_dns_test.go
+++ b/override/merge_dns_test.go
@@ -43,16 +43,16 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     dns:
-      - 8.8.8.8
-      - 9.9.9.9
+      - !right 8.8.8.8
+      - !left  9.9.9.9
     dns_opt:
-      - use-vc
-      - no-tld-query
+      - !right use-vc
+      - !left  no-tld-query
     dns_search:
-      - dc1.example.com
-      - dc2.example.com
+      - !right dc1.example.com
+      - !left  dc2.example.com
 `)
 }
 
@@ -81,16 +81,16 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     dns:
-      - 8.8.8.8
-      - 10.10.10.10
-      - 9.9.9.9
+      - !right 8.8.8.8
+      - !right 10.10.10.10
+      - !left  9.9.9.9
     dns_opt:
-      - use-vc
-      - no-tld-query
+      - !right use-vc
+      - !left  no-tld-query
     dns_search:
-      - dc1.example.com
-      - dc2.example.com
+      - !right dc1.example.com
+      - !left  dc2.example.com
 `)
 }

--- a/override/merge_env_file_test.go
+++ b/override/merge_env_file_test.go
@@ -36,11 +36,11 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     env_file:
-      - foo.env
-      - bar.env
-      - baz.env
+      - !right foo.env
+      - !left  bar.env
+      - !left  baz.env
 `)
 }
 
@@ -57,10 +57,10 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     env_file:
-      - foo.env
-      - bar.env
+      - !right foo.env
+      - !left  bar.env
 `)
 }
 
@@ -84,8 +84,8 @@ services:
 services:
   test:
     env_file:
-      - foo.env
-      - bar.env
+      - !left foo.env
+      - !left bar.env
 `)
 	})
 
@@ -94,15 +94,15 @@ services:
 services:
   test:
     env_file:
-      - bar.env
-      - foo.env
+      - !right bar.env
+      - !left  foo.env
 `)
 	})
 
 	r = `
 services:
   test:
-    env_file: 
+    env_file:
       - path: foo.env
         required: true
 `
@@ -111,9 +111,9 @@ services:
 services:
   test:
     env_file:
-      - bar.env
-      - path: foo.env
-        required: true
+      - !right bar.env
+      - path: !left foo.env
+        required: !left true
 
 `)
 	})

--- a/override/merge_environment_test.go
+++ b/override/merge_environment_test.go
@@ -37,12 +37,12 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     environment:
-      - FOO=BAR
-      - QIX=ZOT
-      - EMPTY=
-      - NIL
+      - !right FOO=BAR
+      - !left  QIX=ZOT
+      - !left  EMPTY=
+      - !left  NIL
 `)
 }
 
@@ -63,12 +63,12 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     environment:
-      - FOO=BAR
-      - EMPTY=
-      - NIL
-      - QIX=ZOT
+      - !right FOO=BAR
+      - !left  EMPTY=
+      - !left  NIL
+      - !left  QIX=ZOT
 `)
 }
 
@@ -87,10 +87,10 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     environment:
-      - FOO=BAR
-      - QIX=ZOT
+      - !right FOO=BAR
+      - !left  QIX=ZOT
 `)
 }
 
@@ -109,6 +109,6 @@ services:
 services:
   test:
     environment:
-      - FOO=3
+      - !left FOO=3
 `)
 }

--- a/override/merge_extra_hosts_test.go
+++ b/override/merge_extra_hosts_test.go
@@ -37,11 +37,11 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     extra_hosts:
-      - example.com=1.2.3.4
-      - localhost=127.0.0.1
-      - example.com=4.3.2.1
+      - !left example.com=1.2.3.4
+      - !left localhost=127.0.0.1
+      - !left example.com=4.3.2.1
 `)
 }
 
@@ -61,11 +61,11 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     extra_hosts:
-      - example.com=1.2.3.4
-      - example.com=4.3.2.1
-      - localhost=127.0.0.1
+      - !left example.com=1.2.3.4
+      - !left example.com=4.3.2.1
+      - !left localhost=127.0.0.1
 `)
 }
 
@@ -86,10 +86,10 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     extra_hosts:
-      - example.com=1.2.3.4
-      - localhost=127.0.0.1
-      - example.com=4.3.2.1
+      - !left example.com=1.2.3.4
+      - !left localhost=127.0.0.1
+      - !left example.com=4.3.2.1
 `)
 }

--- a/override/merge_labels_test.go
+++ b/override/merge_labels_test.go
@@ -37,12 +37,12 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     labels:
-      - FOO=BAR
-      - QIX=ZOT
-      - EMPTY=
-      - NIL
+      - !right FOO=BAR
+      - !left  QIX=ZOT
+      - !left  EMPTY=
+      - !left  NIL
 `)
 }
 
@@ -63,12 +63,12 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     labels:
-      - FOO=BAR
-      - EMPTY=
-      - NIL
-      - QIX=ZOT
+      - !right FOO=BAR
+      - !left  EMPTY=
+      - !left  NIL
+      - !left  QIX=ZOT
 `)
 }
 
@@ -87,10 +87,10 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     labels:
-      - FOO=BAR
-      - QIX=ZOT
+      - !right FOO=BAR
+      - !left  QIX=ZOT
 `)
 }
 
@@ -109,7 +109,7 @@ services:
 services:
   test:
     labels:
-      - FOO=3
+      - !left FOO=3
 `)
 }
 
@@ -132,13 +132,13 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     deploy:
       labels:
-        - FOO=BAR
-        - QIX=ZOT
-        - EMPTY=
-        - NIL
+        - !right FOO=BAR
+        - !left  QIX=ZOT
+        - !left  EMPTY=
+        - !left  NIL
 `)
 }
 
@@ -161,13 +161,13 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     deploy:
       labels:
-        - FOO=BAR
-        - EMPTY=
-        - NIL
-        - QIX=ZOT
+        - !right FOO=BAR
+        - !left  EMPTY=
+        - !left  NIL
+        - !left  QIX=ZOT
 `)
 }
 
@@ -188,11 +188,11 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     deploy:
       labels:
-        - FOO=BAR
-        - QIX=ZOT
+        - !right FOO=BAR
+        - !left  QIX=ZOT
 `)
 }
 
@@ -214,7 +214,7 @@ services:
   test:
     deploy:
       labels:
-        - FOO=3
+        - !left FOO=3
 `)
 }
 
@@ -237,13 +237,13 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     build:
       labels:
-        - FOO=BAR
-        - QIX=ZOT
-        - EMPTY=
-        - NIL
+        - !right FOO=BAR
+        - !left  QIX=ZOT
+        - !left  EMPTY=
+        - !left  NIL
 `)
 }
 
@@ -266,13 +266,13 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     build:
       labels:
-        - FOO=BAR
-        - EMPTY=
-        - NIL
-        - QIX=ZOT
+        - !right FOO=BAR
+        - !left  EMPTY=
+        - !left  NIL
+        - !left  QIX=ZOT
 `)
 }
 
@@ -293,11 +293,11 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     build:
       labels:
-        - FOO=BAR
-        - QIX=ZOT
+        - !right FOO=BAR
+        - !left  QIX=ZOT
 `)
 }
 
@@ -319,6 +319,6 @@ services:
   test:
     build:
       labels:
-        - FOO=3
+        - !left FOO=3
 `)
 }

--- a/override/merge_links_test.go
+++ b/override/merge_links_test.go
@@ -36,9 +36,9 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     links:
-      - service1
-      - service2=alias1
+      - !right service1
+      - !left  service2=alias1
 `)
 }

--- a/override/merge_logging_test.go
+++ b/override/merge_logging_test.go
@@ -40,11 +40,11 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     logging:
-      driver: syslog
+      driver: !left syslog
       options:
-        syslog-address: "tcp://127.0.0.1:123"
+        syslog-address: !left "tcp://127.0.0.1:123"
 `)
 }
 
@@ -68,11 +68,11 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     logging:
-      driver: syslog
+      driver: !left syslog
       options:
-        syslog-address: "tcp://127.0.0.1:123"
+        syslog-address: !left "tcp://127.0.0.1:123"
 `)
 }
 
@@ -94,10 +94,10 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     logging:
       options:
-        max-size: "10m"
-        max-file: 3
+        max-size: !right "10m"
+        max-file: !left  3
 `)
 }

--- a/override/merge_mem_test.go
+++ b/override/merge_mem_test.go
@@ -35,7 +35,7 @@ services:
 		assertMergeYaml(t, r, l, `
 services:
   test:
-    mem_limit: 256m
+    mem_limit: !left 256m
 `)
 	})
 
@@ -43,7 +43,7 @@ services:
 		assertMergeYaml(t, l, r, `
 services:
   test:
-    mem_limit: 1
+    mem_limit: !left 1
 `)
 	})
 }

--- a/override/merge_networks_test.go
+++ b/override/merge_networks_test.go
@@ -36,10 +36,10 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     networks:
-      front-network:
-      back-network:
+      front-network: !left
+      back-network:  !right
 `)
 }
 
@@ -74,21 +74,21 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     networks:
       network1:
         aliases:
-          - alias1
-          - alias2
-          - alias3
+          - !left  alias1
+          - !right alias2
+          - !left  alias3
         link_local_ips:
-          - 57.123.22.11
-          - 57.123.22.13
-          - 57.123.22.12
+          - !right 57.123.22.11
+          - !left  57.123.22.13
+          - !left  57.123.22.12
       network2:
         aliases:
-          - alias1
-          - alias3
+          - !right alias1
+          - !right alias3
 `)
 }
 
@@ -120,21 +120,21 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !left foo
     networks:
-      front-network:
-      back-network:
+      front-network: !right
+      back-network:  !right
       network1:
         aliases:
-          - alias1
-          - alias2
+          - !left alias1
+          - !left alias2
         link_local_ips:
-          - 57.123.22.11
-          - 57.123.22.13
+          - !left 57.123.22.11
+          - !left 57.123.22.13
       network2:
         aliases:
-          - alias1
-          - alias3
+          - !left alias1
+          - !left alias3
 `)
 }
 
@@ -194,35 +194,35 @@ networks:
 `, `
 services:
   test:
-    image: foo
+    image: !left foo
 networks:
   network1:
     ipam:
       config:
-        - subnet: 172.28.0.0/16
-          ip_range: 172.28.5.1/24
-          gateway: 172.28.5.254
+        - subnet: !left 172.28.0.0/16
+          ip_range: !left 172.28.5.1/24
+          gateway: !left 172.28.5.254
           aux_addresses:
-            host1: 172.28.1.5
-            host2: 172.28.1.4
-            host3: 172.28.1.7
-            host4: 172.28.1.10
-        - subnet: 172.28.10.0/16
-          ip_range: 172.28.10.1/24
-          gateway: 172.28.10.254
+            host1: !left  172.28.1.5
+            host2: !left  172.28.1.4
+            host3: !right 172.28.1.7
+            host4: !left  172.28.1.10
+        - subnet: !left 172.28.10.0/16
+          ip_range: !left 172.28.10.1/24
+          gateway: !left 172.28.10.254
           aux_addresses:
-            host1: 172.28.10.5
-            host2: 172.28.10.4
-            host3: 172.28.10.10
+            host1: !left 172.28.10.5
+            host2: !left 172.28.10.4
+            host3: !left 172.28.10.10
       options:
-        foo: bar
-        bar: foo
-        baz: "0"
+        foo: !right bar
+        bar: !left  foo
+        baz: !left  "0"
     labels:
-      - "com.example.department=Finance"
-      - "com.example.description=Financial transaction network"
-      - "com.example.label-with-empty-value="
-      - "com.example.department-new=New"
-  network2:
+      - !right "com.example.department=Finance"
+      - !left  "com.example.description=Financial transaction network"
+      - !left  "com.example.label-with-empty-value="
+      - !left  "com.example.department-new=New"
+  network2: !left
 `)
 }

--- a/override/merge_profiles_test.go
+++ b/override/merge_profiles_test.go
@@ -37,10 +37,10 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     profiles:
-      - profile1
-      - profile2
-      - profile3
+      - !right profile1
+      - !left  profile2
+      - !left  profile3
 `)
 }

--- a/override/merge_sysctls_test.go
+++ b/override/merge_sysctls_test.go
@@ -35,10 +35,10 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     sysctls:
-      - net.ipv6.conf.all.disable_ipv6=1
-      - net.ipv4.tcp_keepalive_time=300
+      - !right net.ipv6.conf.all.disable_ipv6=1
+      - !left  net.ipv4.tcp_keepalive_time=300
 `)
 }
 
@@ -57,10 +57,10 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     sysctls:
-      - net.ipv6.conf.all.disable_ipv6=1
-      - net.ipv4.tcp_keepalive_time=300
+      - !right net.ipv6.conf.all.disable_ipv6=1
+      - !left  net.ipv4.tcp_keepalive_time=300
 `)
 }
 
@@ -79,10 +79,10 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     sysctls:
-      - net.ipv6.conf.all.disable_ipv6=1
-      - net.ipv4.tcp_keepalive_time=300
+      - !right net.ipv6.conf.all.disable_ipv6=1
+      - !left  net.ipv4.tcp_keepalive_time=300
 `)
 }
 
@@ -101,6 +101,6 @@ services:
 services:
   test:
     sysctls:
-      - net.ipv4.tcp_keepalive_time=3
+      - !left net.ipv4.tcp_keepalive_time=3
 `)
 }

--- a/override/merge_test.go
+++ b/override/merge_test.go
@@ -19,6 +19,7 @@ package override
 import (
 	"testing"
 
+	"github.com/compose-spec/compose-go/v2/utils"
 	"gopkg.in/yaml.v3"
 	"gotest.tools/v3/assert"
 )
@@ -49,7 +50,26 @@ services:
 	assert.DeepEqual(t, got, unmarshal(t, expected))
 }
 
-func assertMergeYaml(t *testing.T, right string, left string, want string) {
+func Test_mergeOverridesWithSourceInfo(t *testing.T) {
+	assertMergeYaml(t, `
+services:
+  test:
+    image: foo
+    scale: 1
+`, `
+services:
+  test:
+    image: bar
+    scale: 2
+`, `
+services:
+  test:
+    image: !left bar
+    scale: !left 2
+`)
+}
+
+func assertMergeYamlOriginal(t *testing.T, right string, left string, want string) {
 	t.Helper()
 	got, err := Merge(unmarshal(t, right), unmarshal(t, left))
 	assert.NilError(t, err)
@@ -58,10 +78,100 @@ func assertMergeYaml(t *testing.T, right string, left string, want string) {
 	assert.DeepEqual(t, got, unmarshal(t, want))
 }
 
+func assertMergeYaml(t *testing.T, right string, left string, want string) {
+	t.Helper()
+	got, err := Merge(attachSourceInfo(t, "right", unmarshal(t, right)), attachSourceInfo(t, "left", unmarshal(t, left)))
+	assert.NilError(t, err)
+	got, err = EnforceUnicity(got)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, got, unmarshal(t, want))
+}
+
+type sourceTagProcessor struct {
+	target map[string]any
+}
+
+// UnmarshalYAML implement yaml.Unmarshaler
+func (p *sourceTagProcessor) UnmarshalYAML(node *yaml.Node) error {
+	target, err := p.resolveModelWithSourceTag(node)
+	for k, v := range target.(map[string]any) {
+		p.target[k] = v
+	}
+	return err
+}
+
+func (p *sourceTagProcessor) resolveModelWithSourceTag(node *yaml.Node) (any, error) {
+	switch node.Tag {
+	case "!right", "!left":
+		source := node.Tag[1:]
+		node.Tag = "" // Unset node tag so it does not interfere with decoding
+		var value any
+		if err := node.Decode(&value); err != nil {
+			return nil, err
+		}
+		return utils.Pair{First: value, Second: source}, nil
+	}
+	switch node.Kind {
+	case yaml.SequenceNode:
+		values := []any{}
+		for _, v := range node.Content {
+			value, err := p.resolveModelWithSourceTag(v)
+			if err != nil {
+				return nil, err
+			}
+			values = append(values, value)
+		}
+		return values, nil
+	case yaml.MappingNode:
+		var key string
+		values := make(map[string]any)
+		for idx, v := range node.Content {
+			if idx%2 == 0 {
+				key = v.Value
+			} else {
+				resolved, err := p.resolveModelWithSourceTag(v)
+				if err != nil {
+					return nil, err
+				}
+				values[key] = resolved
+			}
+		}
+		return values, nil
+	default:
+		var value any
+		if err := node.Decode(&value); err != nil {
+			return nil, err
+		}
+		return value, nil
+	}
+}
+
 func unmarshal(t *testing.T, s string) map[string]any {
 	t.Helper()
-	var val map[string]any
-	err := yaml.Unmarshal([]byte(s), &val)
+	val := map[string]any{}
+	err := yaml.Unmarshal([]byte(s), &sourceTagProcessor{val})
 	assert.NilError(t, err, s)
 	return val
+}
+
+func attachSourceInfo(t *testing.T, sourceName string, source map[string]any) map[string]any {
+	t.Helper()
+	for k, v := range source {
+		switch v := v.(type) {
+		case map[string]any:
+			source[k] = attachSourceInfo(t, sourceName, v)
+		case []any:
+			for i, item := range v {
+				switch item := item.(type) {
+				case map[string]any:
+					v[i] = attachSourceInfo(t, sourceName, item)
+				default:
+					v[i] = utils.Pair{First: item, Second: sourceName}
+				}
+			}
+		default:
+			source[k] = utils.Pair{First: v, Second: sourceName}
+		}
+	}
+	return source
 }

--- a/override/merge_tmpfs_test.go
+++ b/override/merge_tmpfs_test.go
@@ -37,11 +37,11 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     tmpfs:
-      - /foo
-      - /bar
-      - /baz
+      - !left /foo
+      - !left /bar
+      - !left /baz
 `)
 }
 
@@ -58,10 +58,10 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     tmpfs:
-      - /foo
-      - /bar
+      - !right /foo
+      - !left  /bar
 `)
 }
 
@@ -85,10 +85,10 @@ services:
 		assertMergeYaml(t, r, l, `
 services:
   test:
-    image: foo
+    image: !right foo
     tmpfs:
-      - /foo
-      - /bar
+      - !left /foo
+      - !left /bar
 `)
 	})
 
@@ -96,10 +96,10 @@ services:
 		assertMergeYaml(t, l, r, `
 services:
   test:
-    image: foo
+    image: !left foo
     tmpfs:
-      - /bar
-      - /foo
+      - !right /bar
+      - !left  /foo
 `)
 	})
 }

--- a/override/merge_ulimits_test.go
+++ b/override/merge_ulimits_test.go
@@ -26,11 +26,11 @@ services:
   test:
     image: foo
     ulimits:
-      nofile: 
+      nofile:
           soft: 20000
           hard: 40000
       nproc: 65535
-      locks: 
+      locks:
           soft: 20000
           hard: 40000
 `, `
@@ -38,24 +38,24 @@ services:
   test:
     image: foo
     ulimits:
-      nofile: 
+      nofile:
           soft: 10000
           hard: 40000
-      nproc: 
+      nproc:
           soft: 65535
       locks:
           hard: 65535
 `, `
 services:
   test:
-    image: foo
+    image: !left foo
     ulimits:
-      nofile: 
-          soft: 10000
-          hard: 40000
-      nproc: 
-          soft: 65535
+      nofile:
+          soft: !left 10000
+          hard: !left 40000
+      nproc:
+          soft: !left 65535
       locks:
-          hard: 65535
+          hard: !left 65535
 `)
 }

--- a/override/merge_volumes_test.go
+++ b/override/merge_volumes_test.go
@@ -38,12 +38,12 @@ services:
 `, `
 services:
   test:
-    image: foo
+    image: !right foo
     volumes:
-      - a:/a
-      - type: bind
-        source: ./b
-        target: /b
-      - c:/c
+      - !right a:/a
+      - type: !right bind
+        source: !right ./b
+        target: !right /b
+      - !left c:/c
 `)
 }

--- a/override/uncity.go
+++ b/override/uncity.go
@@ -92,7 +92,7 @@ func enforceUnicity(value any, p tree.Path) (any, error) {
 				seq := []any{}
 				keys := map[string]int{}
 				for i, entry := range v {
-					key, err := indexer(utils.UnwrapPair(entry), p.Next(strconv.Itoa(i)))
+					key, err := indexer(utils.UnwrapPair(entry), p.NextIndex(i))
 					if err != nil {
 						return nil, err
 					}

--- a/paths/context.go
+++ b/paths/context.go
@@ -16,9 +16,13 @@
 
 package paths
 
-import "strings"
+import (
+	"strings"
 
-func (r *relativePathsResolver) absContextPath(value any) (any, error) {
+	"github.com/compose-spec/compose-go/v2/tree"
+)
+
+func (r *relativePathsResolver) absContextPath(value any, treePath tree.Path) (any, error) {
 	v := value.(string)
 	if strings.Contains(v, "://") { // `docker-image://` or any builder specific context type
 		return v, nil
@@ -26,7 +30,7 @@ func (r *relativePathsResolver) absContextPath(value any) (any, error) {
 	if isRemoteContext(v) {
 		return v, nil
 	}
-	return r.absPath(v)
+	return r.absPath(v, treePath)
 }
 
 // isRemoteContext returns true if the value is a Git reference or HTTP(S) URL.

--- a/paths/extends.go
+++ b/paths/extends.go
@@ -16,10 +16,12 @@
 
 package paths
 
-func (r *relativePathsResolver) absExtendsPath(value any) (any, error) {
+import "github.com/compose-spec/compose-go/v2/tree"
+
+func (r *relativePathsResolver) absExtendsPath(value any, treePath tree.Path) (any, error) {
 	v := value.(string)
 	if r.isRemoteResource(v) {
 		return v, nil
 	}
-	return r.absPath(v)
+	return r.absPath(v, treePath)
 }

--- a/paths/resolve.go
+++ b/paths/resolve.go
@@ -20,18 +20,25 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strconv"
 
 	"github.com/compose-spec/compose-go/v2/tree"
 	"github.com/compose-spec/compose-go/v2/types"
 )
 
-type resolver func(any) (any, error)
+type resolver func(any, tree.Path) (any, error)
 
 // ResolveRelativePaths make relative paths absolute
 func ResolveRelativePaths(project map[string]any, base string, remotes []RemoteResource) error {
+	return ResolveRelativePathsWithBaseMapping(project, base, remotes, nil)
+}
+
+// ResolveRelativePathsWithBaseMapping make relative paths absolute, where base dir can be overridden according to field path
+func ResolveRelativePathsWithBaseMapping(project map[string]any, base string, remotes []RemoteResource, baseMapping map[tree.Path]string) error {
 	r := relativePathsResolver{
-		workingDir: base,
-		remotes:    remotes,
+		workingDir:        base,
+		workingDirMapping: baseMapping,
+		remotes:           remotes,
 	}
 	r.resolvers = map[tree.Path]resolver{
 		"services.*.build.context":               r.absContextPath,
@@ -55,9 +62,10 @@ func ResolveRelativePaths(project map[string]any, base string, remotes []RemoteR
 type RemoteResource func(path string) bool
 
 type relativePathsResolver struct {
-	workingDir string
-	remotes    []RemoteResource
-	resolvers  map[tree.Path]resolver
+	workingDir        string
+	workingDirMapping map[tree.Path]string
+	remotes           []RemoteResource
+	resolvers         map[tree.Path]resolver
 }
 
 func (r *relativePathsResolver) isRemoteResource(path string) bool {
@@ -69,10 +77,19 @@ func (r *relativePathsResolver) isRemoteResource(path string) bool {
 	return false
 }
 
+func (r *relativePathsResolver) resolveWorkingDir(treePath tree.Path) (string, error) {
+	if r.workingDirMapping != nil {
+		if dir, ok := r.workingDirMapping[treePath]; ok {
+			return dir, nil
+		}
+	}
+	return r.workingDir, nil
+}
+
 func (r *relativePathsResolver) resolveRelativePaths(value any, p tree.Path) (any, error) {
 	for pattern, resolver := range r.resolvers {
 		if p.Matches(pattern) {
-			return resolver(value)
+			return resolver(value, p)
 		}
 	}
 	switch v := value.(type) {
@@ -86,7 +103,7 @@ func (r *relativePathsResolver) resolveRelativePaths(value any, p tree.Path) (an
 		}
 	case []any:
 		for i, e := range v {
-			resolved, err := r.resolveRelativePaths(e, p.Next("[]"))
+			resolved, err := r.resolveRelativePaths(e, p.Next(strconv.Itoa(i)))
 			if err != nil {
 				return nil, err
 			}
@@ -96,11 +113,11 @@ func (r *relativePathsResolver) resolveRelativePaths(value any, p tree.Path) (an
 	return value, nil
 }
 
-func (r *relativePathsResolver) absPath(value any) (any, error) {
+func (r *relativePathsResolver) absPath(value any, treePath tree.Path) (any, error) {
 	switch v := value.(type) {
 	case []any:
 		for i, s := range v {
-			abs, err := r.absPath(s)
+			abs, err := r.absPath(s, treePath.Next(strconv.Itoa(i)))
 			if err != nil {
 				return nil, err
 			}
@@ -113,7 +130,11 @@ func (r *relativePathsResolver) absPath(value any) (any, error) {
 			return v, nil
 		}
 		if v != "" {
-			return filepath.Join(r.workingDir, v), nil
+			workingDir, err := r.resolveWorkingDir(treePath)
+			if err != nil {
+				return nil, err
+			}
+			return filepath.Join(workingDir, v), nil
 		}
 		return v, nil
 	}
@@ -121,7 +142,7 @@ func (r *relativePathsResolver) absPath(value any) (any, error) {
 	return nil, fmt.Errorf("unexpected type %T", value)
 }
 
-func (r *relativePathsResolver) absVolumeMount(a any) (any, error) {
+func (r *relativePathsResolver) absVolumeMount(a any, treePath tree.Path) (any, error) {
 	switch vol := a.(type) {
 	case map[string]any:
 		if vol["type"] != types.VolumeTypeBind {
@@ -131,7 +152,7 @@ func (r *relativePathsResolver) absVolumeMount(a any) (any, error) {
 		if !ok {
 			return nil, errors.New(`invalid mount config for type "bind": field Source must not be empty`)
 		}
-		abs, err := r.maybeUnixPath(src.(string))
+		abs, err := r.maybeUnixPath(src.(string), treePath.Next("source"))
 		if err != nil {
 			return nil, err
 		}
@@ -143,7 +164,7 @@ func (r *relativePathsResolver) absVolumeMount(a any) (any, error) {
 	}
 }
 
-func (r *relativePathsResolver) volumeDriverOpts(a any) (any, error) {
+func (r *relativePathsResolver) volumeDriverOpts(a any, treePath tree.Path) (any, error) {
 	if a == nil {
 		return nil, nil
 	}
@@ -158,7 +179,7 @@ func (r *relativePathsResolver) volumeDriverOpts(a any) (any, error) {
 	opts := do.(map[string]any)
 	if dev, ok := opts["device"]; opts["o"] == "bind" && ok {
 		// This is actually a bind mount
-		path, err := r.maybeUnixPath(dev)
+		path, err := r.maybeUnixPath(dev, treePath)
 		if err != nil {
 			return nil, err
 		}

--- a/paths/resolve.go
+++ b/paths/resolve.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"strconv"
 
 	"github.com/compose-spec/compose-go/v2/tree"
 	"github.com/compose-spec/compose-go/v2/types"
@@ -103,7 +102,7 @@ func (r *relativePathsResolver) resolveRelativePaths(value any, p tree.Path) (an
 		}
 	case []any:
 		for i, e := range v {
-			resolved, err := r.resolveRelativePaths(e, p.Next(strconv.Itoa(i)))
+			resolved, err := r.resolveRelativePaths(e, p.NextIndex(i))
 			if err != nil {
 				return nil, err
 			}
@@ -117,7 +116,7 @@ func (r *relativePathsResolver) absPath(value any, treePath tree.Path) (any, err
 	switch v := value.(type) {
 	case []any:
 		for i, s := range v {
-			abs, err := r.absPath(s, treePath.Next(strconv.Itoa(i)))
+			abs, err := r.absPath(s, treePath.NextIndex(i))
 			if err != nil {
 				return nil, err
 			}

--- a/paths/unix.go
+++ b/paths/unix.go
@@ -20,10 +20,11 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/compose-spec/compose-go/v2/tree"
 	"github.com/compose-spec/compose-go/v2/utils"
 )
 
-func (r *relativePathsResolver) maybeUnixPath(a any) (any, error) {
+func (r *relativePathsResolver) maybeUnixPath(a any, treePath tree.Path) (any, error) {
 	p := a.(string)
 	p = ExpandUser(p)
 	// Check if source is an absolute path (either Unix or Windows), to
@@ -36,13 +37,17 @@ func (r *relativePathsResolver) maybeUnixPath(a any) (any, error) {
 		if filepath.IsAbs(p) {
 			return p, nil
 		}
-		return filepath.Join(r.workingDir, p), nil
+		workingDir, err := r.resolveWorkingDir(treePath)
+		if err != nil {
+			return nil, err
+		}
+		return filepath.Join(workingDir, p), nil
 	}
 	return p, nil
 }
 
-func (r *relativePathsResolver) absSymbolicLink(value any) (any, error) {
-	abs, err := r.absPath(value)
+func (r *relativePathsResolver) absSymbolicLink(value any, treePath tree.Path) (any, error) {
+	abs, err := r.absPath(value, treePath)
 	if err != nil {
 		return nil, err
 	}

--- a/transform/build.go
+++ b/transform/build.go
@@ -39,7 +39,7 @@ func defaultBuildContext(data any, _ tree.Path, _ bool) (any, error) {
 	switch v := data.(type) {
 	case map[string]any:
 		if _, ok := v["context"]; !ok {
-			v["context"] = "."
+			setMappingValue(v, "context", ".")
 		}
 		return v, nil
 	default:

--- a/transform/canonical.go
+++ b/transform/canonical.go
@@ -17,8 +17,6 @@
 package transform
 
 import (
-	"strconv"
-
 	"github.com/compose-spec/compose-go/v2/tree"
 	"github.com/compose-spec/compose-go/v2/utils"
 )
@@ -98,7 +96,7 @@ func transform(data any, p tree.Path, ignoreParseError bool) (any, error) {
 
 func transformSequence(v []any, p tree.Path, ignoreParseError bool) ([]any, error) {
 	for i, e := range v {
-		t, err := transform(e, p.Next("[]"), ignoreParseError)
+		t, err := transform(e, p.NextIndex(i), ignoreParseError)
 		if err != nil {
 			return nil, err
 		}

--- a/transform/defaults.go
+++ b/transform/defaults.go
@@ -69,7 +69,7 @@ func setDefaults(data any, p tree.Path) (any, error) {
 
 func setDefaultsSequence(v []any, p tree.Path) ([]any, error) {
 	for i, e := range v {
-		t, err := setDefaults(e, p.Next("[]"))
+		t, err := setDefaults(e, p.NextIndex(i))
 		if err != nil {
 			return nil, err
 		}

--- a/transform/dependson.go
+++ b/transform/dependson.go
@@ -31,22 +31,20 @@ func transformDependsOn(data any, p tree.Path, _ bool) (any, error) {
 				return nil, fmt.Errorf("%s.%s: unsupported value %s", p, i, v)
 			}
 			if _, ok := d["condition"]; !ok {
-				d["condition"] = "service_started"
+				setMappingValue(d, "condition", "service_started")
 			}
 			if _, ok := d["required"]; !ok {
-				d["required"] = true
+				setMappingValue(d, "required", true)
 			}
 		}
 		return v, nil
 	case []any:
-		d := map[string]any{}
-		for _, k := range v {
-			d[k.(string)] = map[string]any{
+		return convertIntoMapping(v, func(k any) (string, any, error) {
+			return k.(string), map[string]any{
 				"condition": "service_started",
 				"required":  true,
-			}
-		}
-		return d, nil
+			}, nil
+		})
 	default:
 		return data, fmt.Errorf("%s: invalid type %T for depend_on", p, v)
 	}

--- a/transform/devices.go
+++ b/transform/devices.go
@@ -30,7 +30,7 @@ func deviceRequestDefaults(data any, p tree.Path, _ bool) (any, error) {
 	_, hasCount := v["count"]
 	_, hasIds := v["device_ids"]
 	if !hasCount && !hasIds {
-		v["count"] = "all"
+		setMappingValue(v, "count", "all")
 	}
 	return v, nil
 }

--- a/transform/envfile.go
+++ b/transform/envfile.go
@@ -18,14 +18,13 @@ package transform
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/compose-spec/compose-go/v2/tree"
 )
 
 func transformEnvFile(data any, p tree.Path, _ bool) (any, error) {
 	return convertIntoSequence(data, func(i int, e any) (any, error) {
-		return transformEnvFileValue(p.Next(strconv.Itoa(i)), e)
+		return transformEnvFileValue(p.NextIndex(i), e)
 	})
 }
 

--- a/transform/external.go
+++ b/transform/external.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/compose-spec/compose-go/v2/tree"
+	"github.com/compose-spec/compose-go/v2/utils"
 	"github.com/sirupsen/logrus"
 )
 
@@ -38,7 +39,7 @@ func transformMaybeExternal(data any, p tree.Path, ignoreParseError bool) (any, 
 			resource["external"] = true
 			if extname, extNamed := external["name"]; extNamed {
 				logrus.Warnf("%s: external.name is deprecated. Please set name and external: true", p)
-				if named && extname != name {
+				if named && utils.UnwrapPair(extname) != utils.UnwrapPair(name) {
 					return nil, fmt.Errorf("%s: name and external.name conflict; only use name", p)
 				}
 				if !named {

--- a/transform/mapping.go
+++ b/transform/mapping.go
@@ -28,18 +28,17 @@ func transformKeyValue(data any, p tree.Path, ignoreParseError bool) (any, error
 	case map[string]any:
 		return v, nil
 	case []any:
-		mapping := map[string]any{}
-		for _, e := range v {
+		mapping, err := convertIntoMapping(v, func(e any) (string, any, error) {
 			before, after, found := strings.Cut(e.(string), "=")
 			if !found {
-				if ignoreParseError {
-					return data, nil
-				}
-				return nil, fmt.Errorf("%s: invalid value %s, expected key=value", p, e)
+				return "", nil, fmt.Errorf("%s: invalid value %s, expected key=value", p, e)
 			}
-			mapping[before] = after
+			return before, after, nil
+		})
+		if err != nil && ignoreParseError {
+			return v, nil
 		}
-		return mapping, nil
+		return mapping, err
 	default:
 		return nil, fmt.Errorf("%s: invalid type %T", p, v)
 	}

--- a/transform/secrets.go
+++ b/transform/secrets.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/compose-spec/compose-go/v2/tree"
+	"github.com/compose-spec/compose-go/v2/utils"
 )
 
 func transformFileMount(data any, p tree.Path, _ bool) (any, error) {
@@ -40,7 +41,7 @@ func defaultSecretMount(data any, p tree.Path, _ bool) (any, error) {
 	case map[string]any:
 		source := v["source"]
 		if _, ok := v["target"]; !ok {
-			v["target"] = fmt.Sprintf("/run/secrets/%s", source)
+			setMappingValue(v, "target", fmt.Sprintf("/run/secrets/%s", utils.UnwrapPair(source)))
 		}
 		return v, nil
 	default:

--- a/transform/services.go
+++ b/transform/services.go
@@ -30,12 +30,12 @@ func transformService(data any, p tree.Path, ignoreParseError bool) (any, error)
 }
 
 func transformServiceNetworks(data any, _ tree.Path, _ bool) (any, error) {
-	if slice, ok := data.([]any); ok {
-		networks := make(map[string]any, len(slice))
-		for _, net := range slice {
-			networks[net.(string)] = nil
-		}
-		return networks, nil
+	switch value := data.(type) {
+	case []any:
+		return convertIntoMapping(value, func(net any) (string, any, error) {
+			return net.(string), nil, nil
+		})
+	default:
+		return value, nil
 	}
-	return data, nil
 }

--- a/transform/ssh.go
+++ b/transform/ssh.go
@@ -28,23 +28,20 @@ func transformSSH(data any, p tree.Path, _ bool) (any, error) {
 	case map[string]any:
 		return v, nil
 	case []any:
-		result := make(map[string]any, len(v))
-		for _, e := range v {
+		return convertIntoMapping(v, func(e any) (string, any, error) {
 			s, ok := e.(string)
 			if !ok {
-				return nil, fmt.Errorf("invalid ssh key type %T", e)
+				return "", nil, fmt.Errorf("invalid ssh key type %T", e)
 			}
 			id, path, ok := strings.Cut(s, "=")
 			if !ok {
 				if id != "default" {
-					return nil, fmt.Errorf("invalid ssh key %q", s)
+					return "", nil, fmt.Errorf("invalid ssh key %q", s)
 				}
-				result[id] = nil
-				continue
+				return id, nil, nil
 			}
-			result[id] = path
-		}
-		return result, nil
+			return id, path, nil
+		})
 	default:
 		return data, fmt.Errorf("%s: invalid type %T for ssh", p, v)
 	}

--- a/tree/path.go
+++ b/tree/path.go
@@ -79,6 +79,29 @@ func (p Path) Matches(pattern Path) bool {
 	return true
 }
 
+func (p Path) HasPrefix(pattern Path) bool {
+	patternParts := pattern.Parts()
+	parts := p.Parts()
+
+	if len(patternParts) > len(parts) {
+		return false
+	}
+	for index, part := range patternParts {
+		switch patternParts[index] {
+		case PathMatchAll, part:
+			continue
+		case PathMatchList:
+			_, err := strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(part, "["), "]"))
+			if err != nil {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 func (p Path) Last() string {
 	parts := p.Parts()
 	return parts[len(parts)-1]

--- a/tree/path.go
+++ b/tree/path.go
@@ -17,6 +17,7 @@
 package tree
 
 import (
+	"strconv"
 	"strings"
 )
 
@@ -47,6 +48,10 @@ func (p Path) Next(part string) Path {
 	return Path(string(p) + pathSeparator + part)
 }
 
+func (p Path) NextIndex(index int) Path {
+	return p.Next(strconv.Itoa(index))
+}
+
 func (p Path) Parts() []string {
 	return strings.Split(string(p), pathSeparator)
 }
@@ -62,6 +67,11 @@ func (p Path) Matches(pattern Path) bool {
 		switch patternParts[index] {
 		case PathMatchAll, part:
 			continue
+		case PathMatchList:
+			_, err := strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(part, "["), "]"))
+			if err != nil {
+				return false
+			}
 		default:
 			return false
 		}

--- a/tree/path_test.go
+++ b/tree/path_test.go
@@ -62,6 +62,29 @@ func TestPathMatches(t *testing.T) {
 			pattern:  NewPath("one", "two", "three"),
 			expected: true,
 		},
+		{
+			doc:      "pattern match with match-list part",
+			path:     NewPath("one", "123", "three"),
+			pattern:  NewPath("one", PathMatchList, "three"),
+			expected: true,
+		},
+		{
+			doc:      "pattern match with match-list part (with brackets)",
+			path:     NewPath("one", "[0]", "three"),
+			pattern:  NewPath("one", PathMatchList, "three"),
+			expected: true,
+		},
+		{
+			doc:      "pattern match with match-list part (with only brackets)",
+			path:     NewPath("one", "[]", "three"), // "[]" == PathMatchList
+			pattern:  NewPath("one", PathMatchList, "three"),
+			expected: true,
+		},
+		{
+			doc:     "pattern mismatch with match-list part",
+			path:    NewPath("one", "0xa", "three"),
+			pattern: NewPath("one", PathMatchList, "three"),
+		},
 	}
 	for _, testcase := range testcases {
 		assert.Check(t, is.Equal(testcase.expected, testcase.path.Matches(testcase.pattern)))

--- a/utils/pair.go
+++ b/utils/pair.go
@@ -1,0 +1,128 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package utils
+
+import (
+	"strconv"
+
+	"github.com/compose-spec/compose-go/v2/tree"
+)
+
+type Pair struct {
+	First  any
+	Second any
+}
+
+func WrapPair[T any | []any | map[string]any](target T, callback func(tree.Path, any) any) T {
+	var nil T
+	if target, ok := wrapPair(target, tree.NewPath(), callback).(T); ok {
+		return target
+	}
+	return nil
+}
+
+func WrapPairWithValue[T any | []any | map[string]any](target T, value any) T {
+	return WrapPair(target, func(_ tree.Path, _ any) any { return value })
+}
+
+func WrapPairWithValues[T any | []any | map[string]any, U any](target T, values map[tree.Path]U) T {
+	return WrapPair(target, func(p tree.Path, _ any) any { return values[p] })
+}
+
+func wrapPair(value any, path tree.Path, callback func(tree.Path, any) any) any {
+	switch value := value.(type) {
+	case map[string]any:
+		dict := make(map[string]any)
+		for k, v := range value {
+			dict[k] = wrapPair(v, path.Next(k), callback)
+		}
+		return dict
+	case []any:
+		list := make([]any, len(value))
+		for i, v := range value {
+			list[i] = wrapPair(v, path.Next(strconv.Itoa(i)), callback)
+		}
+		return list
+	default:
+		return Pair{First: value, Second: callback(path, value)}
+	}
+}
+
+func UnwrapPair[T any | []any | map[string]any](target T, callbacks ...func(tree.Path, Pair)) T {
+	var nil T
+	if target, ok := unwrapPair(target, tree.NewPath(), callbacks...).(T); ok {
+		return target
+	}
+	return nil
+}
+
+func UnwrapPairWithValues[V any, T any | []any | map[string]any](target T) (T, map[tree.Path]V) {
+	values := map[tree.Path]V{}
+	target = UnwrapPair(target, func(path tree.Path, pair Pair) {
+		if value, ok := pair.Second.(V); ok {
+			values[path] = value
+		}
+	})
+	return target, values
+}
+
+func unwrapPair(value any, path tree.Path, callbacks ...func(tree.Path, Pair)) any {
+	switch value := value.(type) {
+	case map[string]any:
+		dict := make(map[string]any)
+		for k, v := range value {
+			dict[k] = unwrapPair(v, path.Next(k), callbacks...)
+		}
+		return dict
+	case []any:
+		list := make([]any, len(value))
+		for i, v := range value {
+			list[i] = unwrapPair(v, path.Next(strconv.Itoa(i)), callbacks...)
+		}
+		return list
+	case Pair:
+		for _, callback := range callbacks {
+			callback(path, value)
+		}
+		return value.First
+	default:
+		return value
+	}
+}
+
+func TransformPair(target any, callback func(any) any) any {
+	switch target := any(target).(type) {
+	case Pair:
+		newValue := callback(target.First)
+		return WrapPairWithValue(newValue, target.Second) // Recursively wrap new value's fields with second value of the pair
+	default:
+		return callback(target)
+	}
+}
+
+func TransformPairWithError(target any, callback func(any) (any, error)) (any, error) {
+	switch target := any(target).(type) {
+	case Pair:
+		newValue, err := callback(target.First)
+		if err != nil {
+			return nil, err
+		}
+		return WrapPairWithValue(newValue, target.Second), nil
+	default:
+		return callback(target)
+	}
+}

--- a/utils/pair.go
+++ b/utils/pair.go
@@ -17,8 +17,6 @@
 package utils
 
 import (
-	"strconv"
-
 	"github.com/compose-spec/compose-go/v2/tree"
 )
 
@@ -54,7 +52,7 @@ func wrapPair(value any, path tree.Path, callback func(tree.Path, any) any) any 
 	case []any:
 		list := make([]any, len(value))
 		for i, v := range value {
-			list[i] = wrapPair(v, path.Next(strconv.Itoa(i)), callback)
+			list[i] = wrapPair(v, path.NextIndex(i), callback)
 		}
 		return list
 	default:
@@ -91,7 +89,7 @@ func unwrapPair(value any, path tree.Path, callbacks ...func(tree.Path, Pair)) a
 	case []any:
 		list := make([]any, len(value))
 		for i, v := range value {
-			list[i] = unwrapPair(v, path.Next(strconv.Itoa(i)), callbacks...)
+			list[i] = unwrapPair(v, path.NextIndex(i), callbacks...)
 		}
 		return list
 	case Pair:

--- a/utils/pair_test.go
+++ b/utils/pair_test.go
@@ -1,0 +1,248 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/compose-spec/compose-go/v2/tree"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestWrapPairWithValue(t *testing.T) {
+	dict := map[string]any{
+		"a": map[string]any{
+			"b": "2",
+			"c": map[string]any{
+				"d": 3,
+			},
+		},
+		"e": []any{
+			map[string]any{
+				"f": 3,
+				"g": nil,
+			},
+			"4",
+			nil,
+		},
+	}
+
+	ctx := struct{}{}
+	result := WrapPairWithValue(dict, ctx)
+
+	assert.Check(t, is.DeepEqual(result, map[string]any{
+		"a": map[string]any{
+			"b": Pair{First: "2", Second: ctx},
+			"c": map[string]any{
+				"d": Pair{First: 3, Second: ctx},
+			},
+		},
+		"e": []any{
+			map[string]any{
+				"f": Pair{First: 3, Second: ctx},
+				"g": Pair{First: nil, Second: ctx},
+			},
+			Pair{First: "4", Second: ctx},
+			Pair{First: nil, Second: ctx},
+		},
+	}))
+}
+
+func TestWrapPairWithValues(t *testing.T) {
+	dict := map[string]any{
+		"a": map[string]any{
+			"b": "2",
+			"c": map[string]any{
+				"d": 3,
+			},
+		},
+		"e": []any{
+			map[string]any{
+				"f": 3,
+				"g": nil,
+			},
+			"4",
+			nil,
+		},
+	}
+
+	contexts := map[tree.Path]any{
+		tree.NewPath("a", "b"):      "ctx1",
+		tree.NewPath("a", "c", "d"): "ctx1",
+		tree.NewPath("e", "0", "f"): "ctx2",
+		tree.NewPath("e", "0", "g"): "ctx2",
+		tree.NewPath("e", "1"):      "ctx3",
+		tree.NewPath("e", "2"):      "ctx4",
+	}
+	result := WrapPairWithValues(dict, contexts)
+
+	assert.Check(t, is.DeepEqual(result, map[string]any{
+		"a": map[string]any{
+			"b": Pair{First: "2", Second: "ctx1"},
+			"c": map[string]any{
+				"d": Pair{First: 3, Second: "ctx1"},
+			},
+		},
+		"e": []any{
+			map[string]any{
+				"f": Pair{First: 3, Second: "ctx2"},
+				"g": Pair{First: nil, Second: "ctx2"},
+			},
+			Pair{First: "4", Second: "ctx3"},
+			Pair{First: nil, Second: "ctx4"},
+		},
+	}))
+}
+
+func TestUnwrapPair(t *testing.T) {
+	dict := map[string]any{
+		"a": map[string]any{
+			"b": Pair{First: "2", Second: "ctx1"},
+			"c": map[string]any{
+				"d": Pair{First: 3, Second: "ctx1"},
+			},
+		},
+		"e": []any{
+			map[string]any{
+				"f": Pair{First: 3, Second: "ctx2"},
+				"g": Pair{First: nil, Second: "ctx2"},
+			},
+			Pair{First: "4", Second: "ctx3"},
+			Pair{First: nil, Second: "ctx4"},
+		},
+	}
+
+	result := UnwrapPair(dict)
+	assert.Check(t, is.DeepEqual(result, map[string]any{
+		"a": map[string]any{
+			"b": "2",
+			"c": map[string]any{
+				"d": 3,
+			},
+		},
+		"e": []any{
+			map[string]any{
+				"f": 3,
+				"g": nil,
+			},
+			"4",
+			nil,
+		},
+	}))
+}
+
+func TestUnwrapPairWithValues(t *testing.T) {
+	dict := map[string]any{
+		"a": map[string]any{
+			"b": Pair{First: "2", Second: "ctx1"},
+			"c": map[string]any{
+				"d": Pair{First: 3, Second: "ctx1"},
+			},
+		},
+		"e": []any{
+			map[string]any{
+				"f": Pair{First: 3, Second: "ctx2"},
+				"g": Pair{First: nil, Second: "ctx2"},
+			},
+			Pair{First: "4", Second: "ctx3"},
+			Pair{First: nil, Second: "ctx4"},
+		},
+	}
+
+	result, contexts := UnwrapPairWithValues[string](dict)
+	assert.Check(t, is.DeepEqual(result, map[string]any{
+		"a": map[string]any{
+			"b": "2",
+			"c": map[string]any{
+				"d": 3,
+			},
+		},
+		"e": []any{
+			map[string]any{
+				"f": 3,
+				"g": nil,
+			},
+			"4",
+			nil,
+		},
+	}))
+	assert.Check(t, is.DeepEqual(contexts, map[tree.Path]string{
+		tree.NewPath("a", "b"):      "ctx1",
+		tree.NewPath("a", "c", "d"): "ctx1",
+		tree.NewPath("e", "0", "f"): "ctx2",
+		tree.NewPath("e", "0", "g"): "ctx2",
+		tree.NewPath("e", "1"):      "ctx3",
+		tree.NewPath("e", "2"):      "ctx4",
+	}))
+}
+
+func TestTransformPair(t *testing.T) {
+	transform := func(value any) any {
+		switch value := value.(type) {
+		case int:
+			return value + 1
+		case string:
+			return map[string]any{
+				"a": value,
+				"b": value,
+			}
+		default:
+			return value
+		}
+	}
+	testCases := []struct {
+		testCase any
+		expected any
+	}{
+		{
+			testCase: nil,
+			expected: nil,
+		},
+		{
+			testCase: 1,
+			expected: 2,
+		},
+		{
+			testCase: "value",
+			expected: map[string]any{
+				"a": "value",
+				"b": "value",
+			},
+		},
+		{
+			testCase: Pair{First: 1, Second: "ctx1"},
+			expected: Pair{First: 2, Second: "ctx1"},
+		},
+		{
+			testCase: Pair{First: "value", Second: "ctx1"},
+			expected: map[string]any{ // Wrapped recursively
+				"a": Pair{First: "value", Second: "ctx1"},
+				"b": Pair{First: "value", Second: "ctx1"},
+			},
+		},
+		{
+			testCase: map[string]any{"key": "value"},
+			expected: map[string]any{"key": "value"},
+		},
+	}
+
+	for _, tc := range testCases {
+		result := TransformPair(tc.testCase, transform)
+		assert.Check(t, is.DeepEqual(result, tc.expected))
+	}
+}

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -54,8 +54,8 @@ func check(value any, p tree.Path) error {
 			}
 		}
 	case []any:
-		for _, e := range v {
-			err := check(e, p.Next("[]"))
+		for i, e := range v {
+			err := check(e, p.NextIndex(i))
 			if err != nil {
 				return err
 			}

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/tree"
+	"github.com/compose-spec/compose-go/v2/utils"
 )
 
 type checkerFunc func(value any, p tree.Path) error
@@ -41,7 +42,7 @@ func Validate(dict map[string]any) error {
 func check(value any, p tree.Path) error {
 	for pattern, fn := range checks {
 		if p.Matches(pattern) {
-			return fn(value, p)
+			return fn(utils.UnwrapPair(value), p)
 		}
 	}
 	switch v := value.(type) {


### PR DESCRIPTION
This PR adds support for named mappings to `loader` package's model loading process, with properly implemented `interpolate after merge` mechanism. 

### Embed model fields with contexts

Since compose has complex mechanisms for dealing with multiple configurations files: 
1. Multiple config files by `-f`
2. Extends
3. Include

It would be difficult to know in final merged dict that a specific field derives from which config file.

To solves this issue, a new concept is introduced: Embed each field of model dict with a context, and let the contexts participate into computations (`Merge`, `Canonical`, etc.) with fields. After all computations are done, unwrap the contexts from the dict, then we can answer questions like `which config is this field from?` giving any specific field.

### Run interpolate after merge

Interpolation is now run after the final merged dict is ready, to retrieve correct and thorough information when resolving. 

It is properly implemented with the help of embedded contexts, to retain scope information of each field, so variables like `${project[working-dir]}`, `${compose[config-dir]}` can return correctly value.

Some operations is dependent on the interpolated value, like `transform.transformVolumeMount` in `Canonical`, `gojsonschema.Validate`, they're also moved out to run after interpolation (thus after merge).

### `ResolveGlobal` method for Resolver interface

A new method, `ResolveGlobal(ctx, opts)`, is introduced in `NamedMappingsResolver` interface. It is run before model dict is even available, to provide information that can be known at global level, like `env`, `project` mappings. So partial interpolation can happen during `extends` and `include`.

### Related Issues
* https://github.com/docker/compose/issues/11925
* https://github.com/compose-spec/compose-go/pull/651